### PR TITLE
fix(singer_master): 'arggs.ploidy' -> 'args.ploidy' in run_rate_singer call

### DIFF
--- a/SINGER/SINGER/singer_master
+++ b/SINGER/SINGER/singer_master
@@ -299,7 +299,7 @@ def main():
         if (args.resume):
             resume_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, args.seed)
         else:
-            run_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, arggs.ploidy, args.seed) 
+            run_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, args.ploidy, args.seed) 
     return 
 
     if args.mut_map and not args.m:


### PR DESCRIPTION
## Summary

In \`SINGER/SINGER/singer_master\` line 302, the rate-singer branch passes \`arggs.ploidy\` (double 'g') to \`run_rate_singer\`, which raises \`NameError\`. Every other argument on the same call and the adjacent \`run_map_singer\` call on line 317 use the correct \`args.ploidy\`.

Left \`releases/singer-0.1.9-beta-linux-x86_64/singer_master\` untouched — that's built from the source file fixed here and will regenerate on the next release cut.

Closes #43

## Testing

One-character fix in the source script; no other call sites reference \`arggs\`.