### PR TITLE
[bug] fix typo arggs.ploidy -> args.ploidy

### DIFF
--- a/SINGER/SINGER/singer_master
+++ b/SINGER/SINGER/singer_master
@@ -299,7 +299,7 @@ def main():
         if (args.resume):
             resume_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, args.seed)
         else:
-            run_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, arggs.ploidy, args.seed) 
+            run_rate_singer(args.Ne, args.m, args.m*args.ratio, args.start, args.end, args.vcf, args.output, args.n, args.thin, args.polar, args.ploidy, args.seed) 
     return 
 
     if args.mut_map and not args.m:


### PR DESCRIPTION
This typo is throwing an error in `singer_master`